### PR TITLE
Adds support for an Options file

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/IO.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/IO.scala
@@ -34,6 +34,7 @@ object IO {
    * data longer than needed if that is desired.
    */
   case class WriteFile(f: Path, data: Eval[String]) extends Ops[Unit]
+  case class Failed(err: Throwable) extends Ops[Nothing]
 
   type Result[T] = Free[Ops, T]
 
@@ -45,6 +46,9 @@ object IO {
 
   def exists(f: Path): Result[Boolean] =
     liftF[Ops, Boolean](Exists(f))
+
+  def failed[T](t: Throwable): Result[T] =
+    liftF[Ops, T](Failed(t))
 
   def mkdirs(f: Path): Result[Boolean] =
     liftF[Ops, Boolean](MkDirs(f))
@@ -103,6 +107,7 @@ object IO {
           val os = new FileOutputStream(fileFor(f))
           try os.write(d.value.getBytes("UTF-8")) finally { os.close() }
         }
+      case Failed(err) => Xor.left(err)
     }
   }
 }

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -70,7 +70,7 @@ trait MakeDeps {
         val io = for {
           _ <- IO.recursiveRm(IO.Path(model.getOptions.getThirdPartyDirectory.parts))
           _ <- IO.writeUtf8(IO.Path(workspacePath), ws)
-          builds <- Writer.createBuildFiles(targets)
+          builds <- Writer.createBuildFiles(model.getOptions.getBuildHeader, targets)
         } yield builds
 
         // Here we actually run the whole thing

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -7,14 +7,19 @@ import scala.util.{ Failure, Success, Try }
 
 object Writer {
 
-  def createBuildFiles(ts: List[Target]): Result[Int] = {
+  def createBuildFiles(buildHeader: String, ts: List[Target]): Result[Int] = {
     val pathGroups = ts.groupBy(_.name.path).toList
 
     Traverse[List].traverseU(pathGroups) {
       case (filePath, ts) =>
+
+        def withNewline(s: String): String =
+          if (s.isEmpty) ""
+          else s + "\n"
+
         def data = ts.sortBy(_.name.name)
           .map(_.toBazelString)
-          .mkString("", "\n\n", "\n")
+          .mkString(withNewline(buildHeader), "\n\n", "\n")
 
           for {
             b <- IO.exists(filePath)

--- a/src/scala/com/github/johnynek/bazel_deps/maven/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/BUILD
@@ -5,6 +5,7 @@ scala_library(name = "maven",
                   "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
                   "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
                   "//src/scala/com/github/johnynek/bazel_deps:io",
+                  "//src/scala/com/github/johnynek/bazel_deps:writer",
               ],
               visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/maven/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/BUILD
@@ -1,10 +1,14 @@
 scala_library(name = "maven",
               srcs = ["Tool.scala"],
               deps = [
-                  "//3rdparty/jvm/org/typelevel:cats_core",
+                  "//3rdparty/jvm/io/circe:circe_jawn_2_11",
+                  "//3rdparty/jvm/io/circe:circe_core",
                   "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
+                  "//3rdparty/jvm/org/typelevel:cats_core",
+                  "//src/scala/com/github/johnynek/bazel_deps:circeyaml",
                   "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
                   "//src/scala/com/github/johnynek/bazel_deps:io",
+                  "//src/scala/com/github/johnynek/bazel_deps:decoders",
                   "//src/scala/com/github/johnynek/bazel_deps:writer",
               ],
               visibility = ["//visibility:public"])


### PR DESCRIPTION
This accepts an optional second argument for the options to the dependencies.yaml. So, I used:

```
languages: ["java", "scala:2.11.8"]
versionConflictPolicy: highest
#transitivity: runtime_deps # assume maven deps are only needed at runtime, add exports below when not true
resolvers:
  - id: stripenexus
    type: default
    url: https://our.nexus....
buildHeader: load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary", "scala_test")
```